### PR TITLE
Fix compilation on ubuntu noble with FFMPEG 6.0

### DIFF
--- a/src/h264decoder.cpp
+++ b/src/h264decoder.cpp
@@ -34,10 +34,12 @@ H264Decoder::H264Decoder()
   if (!context)
     throw H264InitFailure("cannot allocate context");
 
+#if LIBAVCODEC_VERSION_MAJOR < 60
   // Note: CODEC_CAP_TRUNCATED was prefixed with AV_...
   if(codec->capabilities & AV_CODEC_CAP_TRUNCATED) {
     context->flags |= AV_CODEC_FLAG_TRUNCATED;
-  }  
+  }
+#endif  
 
   int err = avcodec_open2(context, codec, nullptr);
   if (err < 0)


### PR DESCRIPTION
Ubuntu noble ships with FFMPEG 6.0 where `AV_CODEC_CAP_TRUNCATED` is not defined. I based my work of off https://github.com/obsproject/obs-studio/issues/8375